### PR TITLE
[CFX-3603] Adding in prompting files

### DIFF
--- a/.datarobot/backend.yml
+++ b/.datarobot/backend.yml
@@ -1,7 +1,7 @@
 pulumi_config_passphrase:
   env: PULUMI_CONFIG_PASSPHRASE
   type: string
-  default: 123
+  default: "123"
   optional: true
   help: "The passphrase used to encrypt and decrypt the private key. This value is required if you're not using pulumi cloud."
 datarobot_default_use_case:

--- a/.datarobot/backend.yml
+++ b/.datarobot/backend.yml
@@ -4,12 +4,14 @@ pulumi_config_passphrase:
   default: 123
   optional: true
   help: "The passphrase used to encrypt and decrypt the private key. This value is required if you're not using pulumi cloud."
+
 datarobot_default_use_case:
   env: DATAROBOT_DEFAULT_USE_CASE
   type: string
   default:
   optional: true
   help: "The default use case for this application. If not set, a new use case will be created automatically"
+
 data_source:
   type: string
   default:
@@ -18,6 +20,7 @@ data_source:
   options:
     - name: "Google"
     - name: "Box"
+
 google_data_source:
   requires:
     - name: data_source
@@ -33,6 +36,7 @@ google_data_source:
       default:
       optional: false
       help: "The client secret for the Google data source."
+
 box_data_source:
   requires:
     - name: data_source
@@ -48,12 +52,14 @@ box_data_source:
       default:
       optional: false
       help: "The client secret for the Box data source."
+
 session_secret_key:
   env: SESSION_SECRET_KEY
   type: string
   default: ""
   optional: false
   help: "A secret key used to sign session cookies. This should be a long, random string."
+
 datarobot_default_execution_environment:
   env: DATAROBOT_DEFAULT_EXECUTION_ENVIRONMENT
   type: string

--- a/.datarobot/backend.yml
+++ b/.datarobot/backend.yml
@@ -1,0 +1,62 @@
+pulumi_config_passphrase:
+  env: PULUMI_CONFIG_PASSPHRASE
+  type: string
+  default: 123
+  optional: true
+  help: "The passphrase used to encrypt and decrypt the private key. This value is required if you're not using pulumi cloud."
+datarobot_default_use_case:
+  env: DATAROBOT_DEFAULT_USE_CASE
+  type: string
+  default:
+  optional: true
+  help: "The default use case for this application. If not set, a new use case will be created automatically"
+data_source:
+  type: string
+  default:
+  optional: true
+  help: "The data source to use for this application."
+  options:
+    - name: "Google"
+    - name: "Box"
+google_data_source:
+  requires:
+    - name: data_source
+      value: "Google"
+  prompts:
+    - env: GOOGLE_CLIENT_ID
+      type: string
+      default:
+      optional: false
+      help: "The client ID for the Google data source."
+    - env: GOOGLE_CLIENT_SECRET
+      type: string
+      default:
+      optional: false
+      help: "The client secret for the Google data source."
+box_data_source:
+  requires:
+    - name: data_source
+      value: "Box"
+  prompts:
+    - env: BOX_CLIENT_ID
+      type: string
+      default:
+      optional: false
+      help: "The client ID for the Box data source."
+    - env: BOX_CLIENT_SECRET
+      type: string
+      default:
+      optional: false
+      help: "The client secret for the Box data source."
+session_secret_key:
+  env: SESSION_SECRET_KEY
+  type: string
+  default: ""
+  optional: false
+  help: "A secret key used to sign session cookies. This should be a long, random string."
+datarobot_default_execution_environment:
+  env: DATAROBOT_DEFAULT_EXECUTION_ENVIRONMENT
+  type: string
+  default: "[DataRobot] Python 3.11 GenAI Agents"
+  optional: true
+  help: "The default execution environment for this application."

--- a/.datarobot/backend.yml
+++ b/.datarobot/backend.yml
@@ -1,7 +1,7 @@
 pulumi_config_passphrase:
   env: PULUMI_CONFIG_PASSPHRASE
   type: string
-  default: "123"
+  default: 123
   optional: true
   help: "The passphrase used to encrypt and decrypt the private key. This value is required if you're not using pulumi cloud."
 datarobot_default_use_case:

--- a/.datarobot/backend.yml
+++ b/.datarobot/backend.yml
@@ -1,68 +1,54 @@
-pulumi_config_passphrase:
-  env: PULUMI_CONFIG_PASSPHRASE
-  type: string
-  default: 123
-  optional: true
-  help: "The passphrase used to encrypt and decrypt the private key. This value is required if you're not using pulumi cloud."
-
-datarobot_default_use_case:
-  env: DATAROBOT_DEFAULT_USE_CASE
-  type: string
-  default:
-  optional: true
-  help: "The default use case for this application. If not set, a new use case will be created automatically"
-
-data_source:
-  type: string
-  default:
-  optional: true
-  help: "The data source to use for this application."
-  options:
-    - name: "Google"
-    - name: "Box"
+root:
+  - env: PULUMI_CONFIG_PASSPHRASE
+    type: string
+    default: 123
+    optional: true
+    help: "The passphrase used to encrypt and decrypt the private key. This value is required if you're not using pulumi cloud."
+  - env: DATAROBOT_DEFAULT_USE_CASE
+    type: string
+    default:
+    optional: true
+    help: "The default use case for this application. If not set, a new use case will be created automatically"
+  - env: SESSION_SECRET_KEY
+    type: string
+    default: ""
+    optional: false
+    help: "A secret key used to sign session cookies. This should be a long, random string."
+  - env: DATAROBOT_DEFAULT_EXECUTION_ENVIRONMENT
+    type: string
+    default: "[DataRobot] Python 3.11 GenAI Agents"
+    optional: true
+    help: "The default execution environment for this application."
+  - type: string
+    default:
+    optional: true
+    help: "The data source to use for this application."
+    options:
+      - name: "Google"
+        requires: google_data_source
+      - name: "Box"
+        requires: box_data_source
 
 google_data_source:
-  requires:
-    - name: data_source
-      value: "Google"
-  prompts:
-    - env: GOOGLE_CLIENT_ID
-      type: string
-      default:
-      optional: false
-      help: "The client ID for the Google data source."
-    - env: GOOGLE_CLIENT_SECRET
-      type: string
-      default:
-      optional: false
-      help: "The client secret for the Google data source."
+  - env: GOOGLE_CLIENT_ID
+    type: string
+    default:
+    optional: false
+    help: "The client ID for the Google data source."
+  - env: GOOGLE_CLIENT_SECRET
+    type: string
+    default:
+    optional: false
+    help: "The client secret for the Google data source."
 
 box_data_source:
-  requires:
-    - name: data_source
-      value: "Box"
-  prompts:
-    - env: BOX_CLIENT_ID
-      type: string
-      default:
-      optional: false
-      help: "The client ID for the Box data source."
-    - env: BOX_CLIENT_SECRET
-      type: string
-      default:
-      optional: false
-      help: "The client secret for the Box data source."
-
-session_secret_key:
-  env: SESSION_SECRET_KEY
-  type: string
-  default: ""
-  optional: false
-  help: "A secret key used to sign session cookies. This should be a long, random string."
-
-datarobot_default_execution_environment:
-  env: DATAROBOT_DEFAULT_EXECUTION_ENVIRONMENT
-  type: string
-  default: "[DataRobot] Python 3.11 GenAI Agents"
-  optional: true
-  help: "The default execution environment for this application."
+  - env: BOX_CLIENT_ID
+    type: string
+    default:
+    optional: false
+    help: "The client ID for the Box data source."
+  - env: BOX_CLIENT_SECRET
+    type: string
+    default:
+    optional: false
+    help: "The client secret for the Box data source."

--- a/.datarobot/llm.yml
+++ b/.datarobot/llm.yml
@@ -39,8 +39,7 @@ external_llm:
     default: "gpt-3.5-turbo"
     optional: true
     help: "The name of the external LLM model to use."
-  - key: llm_provider
-    type: string
+  - type: string
     default: "OpenAI"
     optional: false
     multiple: true

--- a/.datarobot/llm.yml
+++ b/.datarobot/llm.yml
@@ -1,83 +1,72 @@
-infra_enable_llm:
-  env: INFRA_ENABLE_LLM
-  type: string
-  optional: true
-  help: "Select the type of LLM integration to enable."
-  options:
-    - name: "External LLM"
-      value: "blueprint_with_external_llm.py"
-    - name: "LLM Gateway"
-      value: "blueprint_with_llm_gateway.py"
-    - name: "DataRobot Deployed LLM"
-      value: "deployed_llm.py"
-    - name: "Registered Model with an LLM Blueprint"
-      value: "registered_model.py"
+root:
+  - env: INFRA_ENABLE_LLM
+    type: string
+    optional: true
+    help: "Select the type of LLM integration to enable."
+    options:
+      - name: "LLM Gateway"
+        value: "blueprint_with_llm_gateway.py"
+      - name: "DataRobot Deployed LLM"
+        value: "deployed_llm.py"
+        requires: deployed_llm
+      - name: "Registered Model with an LLM Blueprint"
+        value: "registered_model.py"
+        requires: registered_model
+      - name: "External LLM"
+        value: "blueprint_with_external_llm.py"
+        requires: external_llm
 
 deployed_llm:
-  requires:
-    - name: infra_enable_llm
-      value: "deployed_llm.py"
-  env: TEXTGEN_DEPLOYMENT_ID
-  type: string
-  optional: false
-  help: "The deployment ID of the DataRobot Deployed LLM to use."
+  - env: TEXTGEN_DEPLOYMENT_ID
+    type: string
+    optional: false
+    help: "The deployment ID of the DataRobot Deployed LLM to use."
 
 registered_model:
-  requires:
-    - name: infra_enable_llm
-      value: "registered_model.py"
-  prompts:
-    - env: TEXTGEN_REGISTERED_MODEL_ID
-      type: string
-      optional: false
-      help: "The ID of the registered model with an LLM blueprint to use."
-    - env: DATAROBOT_TIMEOUT_MINUTES
-      type: number
-      default: 30
-      optional: true
-      help: "The timeout in minutes for DataRobot operations. Default is 30 minutes."
+  - env: TEXTGEN_REGISTERED_MODEL_ID
+    type: string
+    optional: false
+    help: "The ID of the registered model with an LLM blueprint to use."
+  - env: DATAROBOT_TIMEOUT_MINUTES
+    type: number
+    default: 30
+    optional: true
+    help: "The timeout in minutes for DataRobot operations. Default is 30 minutes."
 
-llm_model_info:
-  requires:
-    - name: infra_enable_llm
-      value: "blueprint_with_external_llm.py"
-  prompts:
-    - env: LLM_DEFAULT_MODEL
-      type: string
-      default: "gpt-3.5-turbo"
-      optional: true
-      help: "The name of the external LLM model to use."
-    - key: llm_provider
-      type: string
-      default: "OpenAI"
-      optional: false
-      multiple: true
-      options:
-        - name: "OpenAI"
-        - name: "Azure"
-        - name: "VertexAI"
-        - name: "Anthropic"
-        - name: "Bedrock"
-      help: "The provider of the external LLM model. Options are OpenAI, Azure, VertexAI, and/or Anthropic."
+external_llm:
+  - env: LLM_DEFAULT_MODEL
+    type: string
+    default: "gpt-3.5-turbo"
+    optional: true
+    help: "The name of the external LLM model to use."
+  - key: llm_provider
+    type: string
+    default: "OpenAI"
+    optional: false
+    multiple: true
+    options:
+      - name: "OpenAI"
+        requires: openai
+      - name: "Azure"
+      - name: "VertexAI"
+      - name: "Anthropic"
+      - name: "Bedrock"
+    help: "The provider of the external LLM model. Options are OpenAI, Azure, VertexAI, and/or Anthropic."
 
 openai:
-  requires:
-    - name: llm_provider
-      value: "OpenAI"
-  prompts:
-    - env: OPENAI_API_KEY
-      type: string
-      optional: false
-      help: "The API key for OpenAI."
-    - env: OPENAI_API_BASE
-      type: string
-      optional: false
-      help: "The API base URL for OpenAI, usually in the format https://<your_custom_endpoint>.openai.azure.com"
-    - env: OPENAI_API_DEPLOYMENT_ID
-      type: string
-      optional: false
-      help: "The deployment ID for the OpenAI model."
-    - env: OPENAI_API_VERSION
-      type: string
-      optional: false
-      help: "The API version for OpenAI."
+  - env: OPENAI_API_KEY
+    type: string
+    optional: false
+    help: "The API key for OpenAI."
+  - env: OPENAI_API_BASE
+    type: string
+    optional: false
+    help: "The API base URL for OpenAI, usually in the format https://<your_custom_endpoint>.openai.azure.com"
+  - env: OPENAI_API_DEPLOYMENT_ID
+    type: string
+    optional: false
+    help: "The deployment ID for the OpenAI model."
+  - env: OPENAI_API_VERSION
+    type: string
+    optional: false
+    help: "The API version for OpenAI."

--- a/.datarobot/llm.yml
+++ b/.datarobot/llm.yml
@@ -38,44 +38,44 @@ llm_model_info:
     requires:
         - name: infra_enable_llm
           value: "blueprint_with_external_llm.py"
-    llm_default_model:
-        env: LLM_DEFAULT_MODEL
+    prompts:
+        - env: LLM_DEFAULT_MODEL
+          type: string
+          default: "gpt-3.5-turbo"
+          optional: true
+          help: "The name of the external LLM model to use."
+        - key: llm_provider
+          type: string
+          default: "OpenAI"
+          optional: false
+          multiple: true
+          options:
+            - name: "OpenAI"
+            - name: "Azure"
+            - name: "VertexAI"
+            - name: "Anthropic"
+            - name: "Bedrock"
+          help: "The provider of the external LLM model. Options are OpenAI, Azure, VertexAI, and/or Anthropic."
+openai:
+    requires:
+      - name: llm_provider
+        value: "OpenAI"
+    prompts:
+      - env: OPENAI_API_KEY
         type: string
-        default: "gpt-3.5-turbo"
-        optional: true
-        help: "The name of the external LLM model to use."
-    llm_provider:
-        type: string
-        default: "OpenAI"
         optional: false
-        multiple: true
-        options:
-          - name: "OpenAI"
-          - name: "Azure"
-          - name: "VertexAI"
-          - name: "Anthropic"
-          - name: "Bedrock"
-        help: "The provider of the external LLM model. Options are OpenAI, Azure, VertexAI, and/or Anthropic."
-    openai:
-        requires:
-          - name: llm_provider
-            value: "OpenAI"
-        prompts:
-          - env: OPENAI_API_KEY
-            type: string
-            optional: false
-            help: "The API key for OpenAI."
-          - env: OPENAI_API_BASE
-            type: string
-            optional: false
-            help: "The API base URL for OpenAI, usually in the format https://<your_custom_endpoint>.openai.azure.com"
-          - env: OPENAI_API_DEPLOYMENT_ID
-            type: string
-            optional: false
-            help: "The deployment ID for the OpenAI model."
-          - env: OPENAI_API_VERSION
-            type: string
-            optional: false
-            help: "The API version for OpenAI."
+        help: "The API key for OpenAI."
+      - env: OPENAI_API_BASE
+        type: string
+        optional: false
+        help: "The API base URL for OpenAI, usually in the format https://<your_custom_endpoint>.openai.azure.com"
+      - env: OPENAI_API_DEPLOYMENT_ID
+        type: string
+        optional: false
+        help: "The deployment ID for the OpenAI model."
+      - env: OPENAI_API_VERSION
+        type: string
+        optional: false
+        help: "The API version for OpenAI."
 
 

--- a/.datarobot/llm.yml
+++ b/.datarobot/llm.yml
@@ -1,0 +1,81 @@
+infra_enable_llm:
+  env: INFRA_ENABLE_LLM
+  type: string
+  optional: true
+  help: "Select "
+  options:
+    - name: "External LLM"
+      value: "blueprint_with_external_llm.py"
+    - name: "LLM Gateway"
+      value: "blueprint_with_llm_gateway.py"
+    - name: "DataRobot Deployed LLM"
+      value: "deployed_llm.py"
+    - name: "Registered Model with an LLM Blueprint"
+      value: "registered_model.py"
+deployed_llm:
+  requires:
+    - name: infra_enable_llm
+      value: "deployed_llm.py"
+  env: TEXTGEN_DEPLOYMENT_ID
+  type: string
+  optional: false
+  help: "The deployment ID of the DataRobot Deployed LLM to use."
+registered_model:
+  requires:
+    - name: infra_enable_llm
+      value: "registered_model.py"
+  prompts:
+    - env: TEXTGEN_REGISTERED_MODEL_ID
+      type: string
+      optional: false
+      help: "The ID of the registered model with an LLM blueprint to use."
+    - env: DATAROBOT_TIMEOUT_MINUTES
+      type: number
+      default: 30
+      optional: true
+      help: "The timeout in minutes for DataRobot operations. Default is 30 minutes."
+llm_model_info:
+    requires:
+        - name: infra_enable_llm
+          value: "blueprint_with_external_llm.py"
+    llm_default_model:
+        env: LLM_DEFAULT_MODEL
+        type: string
+        default: "gpt-3.5-turbo"
+        optional: true
+        help: "The name of the external LLM model to use."
+    llm_provider:
+        type: string
+        default: "OpenAI"
+        optional: false
+        multiple: true
+        options:
+          - "OpenAI"
+          - "Azure"
+          - "VertexAI"
+          - "Anthropic"
+          - "Bedrock"
+        help: "The provider of the external LLM model. Options are OpenAI, Azure, VertexAI, and/or Anthropic."
+    openai:
+        requires:
+          - name: llm_provider
+            value: "OpenAI"
+        prompts:
+          - env: OPENAI_API_KEY
+            type: string
+            optional: false
+            help: "The API key for OpenAI."
+          - env: OPENAI_API_BASE
+            type: string
+            optional: false
+            help: "The API base URL for OpenAI, usually in the format https://<your_custom_endpoint>.openai.azure.com"
+          - env: OPENAI_API_DEPLOYMENT_ID
+            type: string
+            optional: false
+            help: "The deployment ID for the OpenAI model."
+          - env: OPENAI_API_VERSION
+            type: string
+            optional: false
+            help: "The API version for OpenAI."
+
+

--- a/.datarobot/llm.yml
+++ b/.datarobot/llm.yml
@@ -12,6 +12,7 @@ infra_enable_llm:
       value: "deployed_llm.py"
     - name: "Registered Model with an LLM Blueprint"
       value: "registered_model.py"
+
 deployed_llm:
   requires:
     - name: infra_enable_llm
@@ -20,6 +21,7 @@ deployed_llm:
   type: string
   optional: false
   help: "The deployment ID of the DataRobot Deployed LLM to use."
+
 registered_model:
   requires:
     - name: infra_enable_llm
@@ -34,48 +36,48 @@ registered_model:
       default: 30
       optional: true
       help: "The timeout in minutes for DataRobot operations. Default is 30 minutes."
+
 llm_model_info:
-    requires:
-        - name: infra_enable_llm
-          value: "blueprint_with_external_llm.py"
-    prompts:
-        - env: LLM_DEFAULT_MODEL
-          type: string
-          default: "gpt-3.5-turbo"
-          optional: true
-          help: "The name of the external LLM model to use."
-        - key: llm_provider
-          type: string
-          default: "OpenAI"
-          optional: false
-          multiple: true
-          options:
-            - name: "OpenAI"
-            - name: "Azure"
-            - name: "VertexAI"
-            - name: "Anthropic"
-            - name: "Bedrock"
-          help: "The provider of the external LLM model. Options are OpenAI, Azure, VertexAI, and/or Anthropic."
+  requires:
+    - name: infra_enable_llm
+      value: "blueprint_with_external_llm.py"
+  prompts:
+    - env: LLM_DEFAULT_MODEL
+      type: string
+      default: "gpt-3.5-turbo"
+      optional: true
+      help: "The name of the external LLM model to use."
+    - key: llm_provider
+      type: string
+      default: "OpenAI"
+      optional: false
+      multiple: true
+      options:
+        - name: "OpenAI"
+        - name: "Azure"
+        - name: "VertexAI"
+        - name: "Anthropic"
+        - name: "Bedrock"
+      help: "The provider of the external LLM model. Options are OpenAI, Azure, VertexAI, and/or Anthropic."
+
 openai:
-    requires:
-      - name: llm_provider
-        value: "OpenAI"
-    prompts:
-      - env: OPENAI_API_KEY
-        type: string
-        optional: false
-        help: "The API key for OpenAI."
-      - env: OPENAI_API_BASE
-        type: string
-        optional: false
-        help: "The API base URL for OpenAI, usually in the format https://<your_custom_endpoint>.openai.azure.com"
-      - env: OPENAI_API_DEPLOYMENT_ID
-        type: string
-        optional: false
-        help: "The deployment ID for the OpenAI model."
-      - env: OPENAI_API_VERSION
-        type: string
-        optional: false
-        help: "The API version for OpenAI."
-
-
+  requires:
+    - name: llm_provider
+      value: "OpenAI"
+  prompts:
+    - env: OPENAI_API_KEY
+      type: string
+      optional: false
+      help: "The API key for OpenAI."
+    - env: OPENAI_API_BASE
+      type: string
+      optional: false
+      help: "The API base URL for OpenAI, usually in the format https://<your_custom_endpoint>.openai.azure.com"
+    - env: OPENAI_API_DEPLOYMENT_ID
+      type: string
+      optional: false
+      help: "The deployment ID for the OpenAI model."
+    - env: OPENAI_API_VERSION
+      type: string
+      optional: false
+      help: "The API version for OpenAI."

--- a/.datarobot/llm.yml
+++ b/.datarobot/llm.yml
@@ -2,7 +2,7 @@ infra_enable_llm:
   env: INFRA_ENABLE_LLM
   type: string
   optional: true
-  help: "Select "
+  help: "Select the type of LLM integration to enable."
   options:
     - name: "External LLM"
       value: "blueprint_with_external_llm.py"
@@ -50,11 +50,11 @@ llm_model_info:
         optional: false
         multiple: true
         options:
-          - "OpenAI"
-          - "Azure"
-          - "VertexAI"
-          - "Anthropic"
-          - "Bedrock"
+          - name: "OpenAI"
+          - name: "Azure"
+          - name: "VertexAI"
+          - name: "Anthropic"
+          - name: "Bedrock"
         help: "The provider of the external LLM model. Options are OpenAI, Azure, VertexAI, and/or Anthropic."
     openai:
         requires:


### PR DESCRIPTION
# Summary

In order for the CLI to be able to build prompts to help guide users through the environment set process, we need to add in configuration files to inform what variables are required.

# Rationale

The DR CLI is a golang CLI meant to help users provision, configure, and start Applications as quickly as possible. The environment configuration process can be the most time-consuming and confusing part of the process, so our goal is to simplify the step and guide users through what is required. This PR adds in yaml configurations that help us generate steps in the setup wizard for users.

# Checklist
- [ ] Implementation
- [ ] Update Changelog